### PR TITLE
Fixing errors with GetCostForPointAtRank returning nil

### DIFF
--- a/LibArtifactData-1.0.lua
+++ b/LibArtifactData-1.0.lua
@@ -471,7 +471,7 @@ function lib.GetAcquiredArtifactPower(_, artifactID)
 		total = total + data.unspentPower
 		local rank = 1
 		while rank <= data.numRanksPurchased do
-			total = total + GetCostForPointAtRank(rank)
+			total = total + (GetCostForPointAtRank(rank) or 0)
 			rank = rank + 1
 		end
 
@@ -483,7 +483,7 @@ function lib.GetAcquiredArtifactPower(_, artifactID)
 			total = total + data.unspentPower
 			local rank = 1
 			while rank <= data.numRanksPurchased do
-				total = total + GetCostForPointAtRank(rank)
+				total = total + (GetCostForPointAtRank(rank) or 0)
 				rank = rank + 1
 			end
 		end


### PR DESCRIPTION
This should fix a problem with `GetCostForPointAtRank` returning nil, which seems to be the case while using artifact with relics.
