### PR TITLE
notify scan complete

### DIFF
--- a/LibArtifactData-1.0.lua
+++ b/LibArtifactData-1.0.lua
@@ -307,6 +307,8 @@ local function InitializeScan(event)
 		end
 		RestoreStateAfterScan()
 	end
+	Debug("InitializeScan", "complete. Firing ARTIFACT_SCAN_COMPLETE event.")
+	lib.callbacks:Fire("ARTIFACT_SCAN_COMPLETE", numObtained)
 end
 
 function private.PLAYER_ENTERING_WORLD(event)


### PR DESCRIPTION
Because there are timers and potentially slow runnng processes involved
in getting all artifact data, data cannot be guaranteed to be available
especially at ADDON_LOAD and PLAYER_ENTERING_WORLD events. Even though
ARTIFACT_ADDED and ARTIFACT_EQUIPPED_CHANGED fire, at early load they
may fire before the consuming addon  has established their callbacks.

Have added a fire for ARTIFACT_SCAN_COMPLETE which can be caught and
reacted to appropriately when Artifact Data is definitely available.
